### PR TITLE
remove duplicate, conflicting declaration of hsubghz

### DIFF
--- a/SOFTWARE/BB-STM32WLE-WAN/Core/Src/subghz.c
+++ b/SOFTWARE/BB-STM32WLE-WAN/Core/Src/subghz.c
@@ -24,8 +24,6 @@
 
 /* USER CODE END 0 */
 
-SUBGHZ_HandleTypeDef hsubghz;
-
 /* SUBGHZ init function */
 void MX_SUBGHZ_Init(void)
 {


### PR DESCRIPTION
There are two symbol declarations with the same name:

```
SUBGHZ_HandleTypeDef hsubghz;
```

One is in ./SOFTWARE/BB-STM32WLE-WAN/Core/Src/main.cpp and the other is in ./SOFTWARE/BB-STM32WLE-WAN/Core/Src/subghz.c

Given that subghz.h has an extern definition and "hsubghz" usage is primarily in main.cpp (and this is also where the variable is initialized via MX_SUBGHZ_Init() ), I presume subghz.c is the more sensible place to remove the duplicate.
