### PR TITLE
add missing include to sysmem.c

### DIFF
--- a/SOFTWARE/BB-STM32WLE-WAN/Core/Src/sysmem.c
+++ b/SOFTWARE/BB-STM32WLE-WAN/Core/Src/sysmem.c
@@ -24,6 +24,7 @@
 /* Includes */
 #include <errno.h>
 #include <stdint.h>
+#include <stddef.h>
 
 /**
  * Pointer to the current high watermark of the heap usage


### PR DESCRIPTION
./SOFTWARE/BB-STM32WLE-WAN/Core/Src/sysmem.c is making use of types like "ptrdiff_t", but such types are only declared in stddef.h, which was not included.
