### PR TITLE
add README.md to mention wireless region

### DIFF
--- a/SOFTWARE/BB-STM32WLE-WAN/README.md
+++ b/SOFTWARE/BB-STM32WLE-WAN/README.md
@@ -1,0 +1,8 @@
+# LoRa-STM32WL-DevKIT geographic region
+
+Before using, the geographic region **MUST** be customized by editing:
+
+"#define ACTIVE_REGION" must be modified in ./SOFTWARE/BB-STM32WLE-WAN/LoRaWAN/App/lora_app.h
+
+only one "#define REGION_xxx" should be uncommented in ./SOFTWARE/BB-STM32WLE-WAN/LoRaWAN/Target/lorawan_conf.h
+


### PR DESCRIPTION
I think it is essential for Olimex to document what portions of the source code must be changed for the device to be operable in different geographic regions.

There seem to be at least two modifications necessary (which I've listed in a new README.md), and perhaps Olimex can formally confirm this and add any additional requirements.
