### PR TITLE
software: fix code duplication

### DIFF
--- a/SOFTWARE/BB-STM32WLE-WAN/.gitignore
+++ b/SOFTWARE/BB-STM32WLE-WAN/.gitignore
@@ -1,0 +1,2 @@
+Debug/
+Release/

--- a/SOFTWARE/BB-STM32WLE-WAN/Core/Src/main.c
+++ b/SOFTWARE/BB-STM32WLE-WAN/Core/Src/main.c
@@ -20,6 +20,7 @@
 /* Includes ------------------------------------------------------------------*/
 #include "main.h"
 #include "app_lorawan.h"
+#include "subghz.h"
 
 /* Private includes ----------------------------------------------------------*/
 /* USER CODE BEGIN Includes */
@@ -57,8 +58,6 @@ RTC_HandleTypeDef hrtc;
 
 SPI_HandleTypeDef hspi1;
 
-SUBGHZ_HandleTypeDef hsubghz;
-
 /* USER CODE BEGIN PV */
 BMP280_HandleTypedef bmp280;
 
@@ -82,7 +81,6 @@ static void MX_I2C1_Init(void);
 static void MX_LPUART1_UART_Init(void);
 static void MX_USART1_UART_Init(void);
 static void MX_SPI1_Init(void);
-static void MX_SUBGHZ_Init(void);
 static void MX_RTC_Init(void);
 static void MX_ADC_Init(void);
 /* USER CODE BEGIN PFP */
@@ -649,32 +647,6 @@ static void MX_SPI1_Init(void)
   /* USER CODE BEGIN SPI1_Init 2 */
 
   /* USER CODE END SPI1_Init 2 */
-
-}
-
-/**
-  * @brief SUBGHZ Initialization Function
-  * @param None
-  * @retval None
-  */
-static void MX_SUBGHZ_Init(void)
-{
-
-  /* USER CODE BEGIN SUBGHZ_Init 0 */
-
-  /* USER CODE END SUBGHZ_Init 0 */
-
-  /* USER CODE BEGIN SUBGHZ_Init 1 */
-
-  /* USER CODE END SUBGHZ_Init 1 */
-  hsubghz.Init.BaudratePrescaler = SUBGHZSPI_BAUDRATEPRESCALER_8;
-  if (HAL_SUBGHZ_Init(&hsubghz) != HAL_OK)
-  {
-    Error_Handler();
-  }
-  /* USER CODE BEGIN SUBGHZ_Init 2 */
-
-  /* USER CODE END SUBGHZ_Init 2 */
 
 }
 


### PR DESCRIPTION
fix build error:
```
  arm-none-eabi-gcc -o "BB-STM32WLE-WAN.elf" @"objects.list" -mcpu=cortex-m4 -T"/LoRa-STM32WL-DevKIT/SOFTWARE/BB-STM32WLE-WAN/STM32WLE5CCUX_FLASH.ld" --specs=nosys.specs -Wl,-Map="BB-STM32WLE-WAN.map" -Wl,--gc-sections -static  -mfloat-abi=soft -mthumb -u _printf_float -u _scanf_float -Wl,--start-group -lc -lm -Wl,--end-group
  arm-none-eabi/bin/ld: ./Core/Src/subghz.o:/LoRa-STM32WL-DevKIT/SOFTWARE/BB-STM32WLE-WAN/Debug/../Core/Src/subghz.c:27: multiple definition of `hsubghz'; ./Core/Src/main.o:/LoRa-STM32WL-DevKIT/SOFTWARE/BB-STM32WLE-WAN/Debug/../Core/Src/main.c:60: first defined here
  arm-none-eabi/bin/ld: warning: BB-STM32WLE-WAN.elf has a LOAD segment with RWX permissions
```